### PR TITLE
mysql起動時にdbdbが自動生成したmy.cnfのみ読み込む

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
         run: |
           cd tests
           /bin/bash mongodb-test.sh
-      # - name: Run mysql test
-      #   run: |
-      #     cd tests
-      #     /bin/bash mysql-test.sh
+      - name: Run mysql test
+        run: |
+          cd tests
+          /bin/bash mysql-test.sh
       - name: Run postgresql test
         run: |
           cd tests

--- a/mysql/create.sh
+++ b/mysql/create.sh
@@ -32,6 +32,7 @@ mkdir -p $dir/datadir/$optName
 extractFile $dir $optFileName
 
 $dir/basedir/bin/mysqld \
+  --no-defaults \
   --initialize-insecure \
   --user=$optUser \
   --port=$optPort \

--- a/mysql/start.sh
+++ b/mysql/start.sh
@@ -15,7 +15,7 @@ dir=$currentDir/versions/$optVersion
 exitIfNotExistDir $dir/datadir/$optName
 exitIfRunningPort $optPort
 $dir/basedir/bin/mysqld \
- --defaults-extra-file=$dir/datadir/$optName/my.cnf \
+ --defaults-file=$dir/datadir/$optName/my.cnf \
  --daemonize \
  --user=$optUser \
  --port=$optPort \


### PR DESCRIPTION
- Close #29
- CIサーバなどではmy.cnfがすでに存在する場合があり、mysql起動時に自動で読み込まれてしまいます。dbdb的には意図しない動作になるためdbdbが自動生成したmy.cnfのみを読み込むようにしました
- [上記理由でfailしていたCIでのmysqlテスト](https://github.com/pj8/dbdb/actions/runs/3797564445/jobs/6458614198#step:4:166)を有効化しました。
- [CIテストが成功した](https://github.com/pj8/dbdb/actions/runs/3797615287/jobs/6458708786#step:4:451)ことを確認しました