### PR TITLE
Ubuntuサポートを終了してMySQLバージョン整理する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
         test_script: [
           mongodb-4.4.10.sh,
           mongodb-5.0.3.sh,
-          mysql-5.7.31.sh,
-          mysql-8.0.30.sh,
+          mysql-8.0.41.sh,
+          mysql-8.4.4.sh,
           postgresql-12.4.sh,
           postgresql-13.2.sh,
           redis-6.2.14.sh,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest]
         test_script: [
           mongodb-4.4.10.sh,
           mongodb-5.0.3.sh,
@@ -21,17 +21,6 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v4
-
-      # WARNING Memory overcommit must be enabled! Without it,
-      # a background save or replication may fail under low memory condition. Being disabled,
-      # it can also cause failures without low memory condition,
-      # see https://github.com/jemalloc/jemalloc/issues/1328.
-      # To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot
-      # or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
-      - name: Enable memory overcommit
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo sysctl vm.overcommit_memory=1
 
       - name: Run test
         run: |

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ cd dbdb
 ./mysql/{create|start|stop|restart|port|status|connect|delete}.sh {name} {mysqlVersion} {port}
 
 # e.g. Create MySQL server.
-./mysql/create.sh mysql1 5.7.31 3306
-
-# e.g. Create another one.
-./mysql/create.sh mysql2 8.0.30 13306
+./mysql/create.sh mysql1 8.0.41 3306
 
 # e.g.
 ./mysql/start.sh   mysql1
@@ -42,15 +39,21 @@ cd dbdb
 ./mysql/connect.sh mysql1
 ./mysql/delete.sh  mysql1
 
+# e.g. Create another one.
+./mysql/create.sh mysql2 9.2.0 13306
+
 # e.g. Create with random port.
-./mysql/create.sh mysql1 5.7.31 random
+./mysql/create.sh mysql3 8.0.41 random
 
 # e.g. Try create, then start server.
-./mysql/create-start.sh mysql1 5.7.31 3306
+./mysql/create-start.sh mysql4 9.2.0 23306
 ```
 
 ### Supported MySQL Versions
 
+- 5.7.31
+- 8.0.23
+- 8.0.30
 - 8.0.41
 - 8.4.4
 - 9.2.0

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ cd dbdb
 
 ### Supported MySQL Versions
 
-- 5.7.31
-- 8.0.23
-- 8.0.30
+- 8.0.41
+- 8.4.4
+- 9.2.0
 
 </div></details>
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -129,7 +129,7 @@ getCommands() {
 
 getRandomPort() {
   while true; do
-    randomPort=$(shuf -i "49152-65535" -n 1 || jot -r 1 49152 65535)
+    randomPort=$(shuf -i "49152-65535" -n 1 2>/dev/null || jot -r 1 49152 65535)
     netstat -a -n | grep ".$randomPort" | grep "LISTEN" 1>/dev/null 2>&1 || break
   done
   echo $randomPort

--- a/tests/mysql-8.0.41.sh
+++ b/tests/mysql-8.0.41.sh
@@ -4,7 +4,7 @@ set -eu
 . ../lib/functions.sh
 
 type=mysql
-version=5.7.31
+version=8.0.41
 
 cd ../$type/..
 

--- a/tests/mysql-8.4.4.sh
+++ b/tests/mysql-8.4.4.sh
@@ -4,7 +4,7 @@ set -eu
 . ../lib/functions.sh
 
 type=mysql
-version=8.0.30
+version=8.4.4
 
 cd ../$type/..
 

--- a/tests/mysql-9.2.0.sh
+++ b/tests/mysql-9.2.0.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+
+. ../lib/functions.sh
+
+type=mysql
+version=9.2.0
+
+cd ../$type/..
+
+date=$(date +%Y%m%d%H%M%S)
+md5="md5"
+[ "$(getOS)" = "linux" ] && md5="md5sum"
+hash=$(echo "dbdb-$date" | $md5 | cut -d ' ' -f 1)
+
+echo "# Test create"
+./$type/create.sh dbdb-test-$hash $version random
+echo "# Test port"
+./$type/port.sh dbdb-test-$hash
+echo "# Test start"
+./$type/start.sh dbdb-test-$hash
+echo "# Test status"
+./$type/status.sh dbdb-test-$hash
+echo "# Test restart"
+./$type/restart.sh dbdb-test-$hash
+echo "# Test stop"
+./$type/stop.sh dbdb-test-$hash
+echo "# Test delete"
+./$type/delete.sh dbdb-test-$hash
+
+echo "# Test create"
+./$type/create.sh -f json dbdb-test-$hash $version random | jq
+echo "# Test port"
+./$type/port.sh -f json dbdb-test-$hash | jq
+echo "# Test start"
+./$type/start.sh -f json dbdb-test-$hash | jq
+echo "# Test status"
+./$type/status.sh -f json dbdb-test-$hash | jq
+echo "# Test restart"
+./$type/restart.sh -f json dbdb-test-$hash | jq
+echo "# Test stop"
+./$type/stop.sh -f json dbdb-test-$hash | jq
+echo "# Test delete"
+./$type/delete.sh -f json dbdb-test-$hash | jq
+
+./dbdb.sh
+./$type/create-start.sh -f json dbdb-test-$hash $version random | jq
+./dbdb.sh -f json | jq
+./$type/delete.sh dbdb-test-$hash
+./dbdb.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- テストの実行環境がmacOSのみとなり、不要な設定が削除されました。これにより、テストプロセスのシンプルさと効率が向上しました。
- **New Features**
	- MySQLのサポートバージョンが更新されました。新たに8.0.41、8.4.4、9.2.0が追加され、8.0.23が削除されました。
	- 新しいテストスクリプト「mysql-9.2.0.sh」が追加され、MySQLデータベースの包括的なテストフレームワークが提供されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->